### PR TITLE
Explicit variables

### DIFF
--- a/src/Circle.php
+++ b/src/Circle.php
@@ -7,7 +7,9 @@
 	class Circle {
 
 		private $api_key;
+		private $baseUrl;
 		private $community_id;
+		private $curl;
 
 		public function __construct(string $api_key) {
 


### PR DESCRIPTION
Set `$baseUrl` and `$curl` variables explicitly on `Circle` class to silence dynamic assignment deprecation notices.